### PR TITLE
Total Clips Counter, Vote Submission Rate Limiting, and More

### DIFF
--- a/app.go
+++ b/app.go
@@ -20,6 +20,7 @@ var commitSHA string
 
 // var votingDeadlineUnix int64 = 1739271194
 var votingDeadlineUnix int64 = time.Date(2025, time.January, 25, 24, 30, 50, 0, time.UTC).Unix()
+var totalUnculledClipsInDb int64
 
 func main() {
 	var err error
@@ -54,6 +55,8 @@ func main() {
 	if err = http.ListenAndServe(envBindAddr, serveMux); err != nil {
 		panic(err)
 	}
+
+	UpdateUnculledClipTotal()
 }
 
 func getEnvOrDefault(key string, defValue string) (value string) {
@@ -62,4 +65,9 @@ func getEnvOrDefault(key string, defValue string) (value string) {
 		value = defValue
 	}
 	return
+}
+
+func UpdateUnculledClipTotal() {
+	totalUnculledClipsInDb = database.GetTotalClips()
+	fmt.Println("The total number of unculled, servable clips is now", totalUnculledClipsInDb)
 }

--- a/app.go
+++ b/app.go
@@ -18,9 +18,8 @@ var envBehindProxy = os.Getenv("CLIPS_BEHIND_PROXY")
 // Provided by build flags
 var commitSHA string
 
-// TODO: Make this less stupid -myth
-// NOTE: THIS WILL BE TIMEZONE SENSITIVE!!!!!!!!!!
-var votingDeadlineUnix int64 = 1739271194
+// var votingDeadlineUnix int64 = 1739271194
+var votingDeadlineUnix int64 = time.Date(2025, time.January, 25, 24, 30, 50, 0, time.UTC).Unix()
 
 func main() {
 	var err error

--- a/app.go
+++ b/app.go
@@ -20,6 +20,8 @@ var commitSHA string
 
 // var votingDeadlineUnix int64 = 1739271194
 var votingDeadlineUnix int64 = time.Date(2025, time.January, 25, 24, 30, 50, 0, time.UTC).Unix()
+var voteCooldown time.Duration = 5
+
 var totalUnculledClipsInDb int64
 
 func main() {

--- a/culling.go
+++ b/culling.go
@@ -33,6 +33,8 @@ func taskCullVideos() {
 			sentry.CaptureException(err)
 		}
 
+		UpdateUnculledClipTotal()
+
 		time.Sleep(intervalCullTask)
 	}
 }

--- a/db.go
+++ b/db.go
@@ -229,7 +229,7 @@ func (db *Database) SubmitUserVote(user User, choice string) (err error) {
 
 	// TODO scale min time to video length
 	// 	?	minTime := max(min(a.length, b.length) / 2, 90 * time.seconds)
-	if vote.startTime.Add(5 * time.Second).After(time.Now()) {
+	if vote.startTime.Add(voteCooldown * time.Second).After(time.Now()) {
 		// User voting too fast, ignore vote
 		return fmt.Errorf("too fast")
 	}

--- a/db.go
+++ b/db.go
@@ -229,8 +229,6 @@ func (db *Database) SubmitUserVote(user User, choice string) (err error) {
 
 	// TODO scale min time to video length
 	// 	?	minTime := max(min(a.length, b.length) / 2, 90 * time.seconds)
-	fmt.Println(vote.startTime.UnixMilli())
-	fmt.Println(time.Now().UnixMilli())
 	if vote.startTime.Add(5 * time.Second).After(time.Now()) {
 		// User voting too fast, ignore vote
 		return fmt.Errorf("too fast")

--- a/db.go
+++ b/db.go
@@ -39,7 +39,7 @@ func (db *Database) setup() (err error) {
 		"CREATE TABLE IF NOT EXISTS culled_videos (url TEXT UNIQUE)", // TODO should be using Ids
 
 		// TODO constraint for (user, video) pairs
-		"CREATE TABLE IF NOT EXISTS votes (user_id INTEGER NOT NULL, video_url TEXT NOT NULL, score INTEGER NOT NULL)",
+		"CREATE TABLE IF NOT EXISTS votes (user_id INTEGER NOT NULL, video_url TEXT NOT NULL, score INTEGER NOT NULL, vote_time INTEGER NOT NULL)",
 		// "CREATE UNIQUE IF NOT EXISTS INDEX idx_votes_user_video ON votes(user_id, video_url)",
 
 		"CREATE TABLE IF NOT EXISTS active_votes ( " +
@@ -250,12 +250,14 @@ func (db *Database) SubmitUserVote(user User, choice string) (err error) {
 	// TODO only supports one round of votes
 	_, err = db.Exec(
 		"DELETE FROM active_votes WHERE user_id = ?;"+
-			"INSERT INTO votes VALUES (?, ?, 1), (?, ?, 0);",
+			"INSERT INTO votes VALUES (?, ?, 1, ?), (?, ?, 0, ?);",
 		user.id,
 		user.id,
 		choice,
+		time.Now().UnixMilli(),
 		user.id,
 		other,
+		time.Now().UnixMilli(),
 	)
 	return
 }

--- a/db.go
+++ b/db.go
@@ -296,3 +296,24 @@ func (db *Database) TallyVotes() (count map[string]int, err error) {
 
 	return
 }
+
+func (db *Database) GetTotalClips() (totalClips int64) {
+	row, err := db.Query("SELECT COUNT() as totalClips FROM videos")
+	if err != nil {
+		return 0
+	}
+	defer row.Close()
+
+	if !row.Next() {
+		// 0 videos available
+		return
+	}
+
+	err = row.Scan(&totalClips)
+
+	if err != nil {
+		return 0
+	}
+
+	return
+}

--- a/db.go
+++ b/db.go
@@ -218,10 +218,10 @@ func (db *Database) SubmitUserVote(user User, choice string) (err error) {
 
 	// TODO scale min time to video length
 	// 	?	minTime := max(min(a.length, b.length) / 2, 90 * time.seconds)
-	// if vote.startTime.Add(30 * time.Second).After(time.Now()) {
-	// 	// User voting too fast, ignore vote
-	// 	return fmt.Errorf("too fast")
-	// }
+	if vote.startTime.Add(5 * time.Second).After(time.Now()) {
+		// User voting too fast, ignore vote
+		return fmt.Errorf("too fast")
+	}
 
 	// TODO limit max time? 12hours?
 

--- a/db.go
+++ b/db.go
@@ -156,7 +156,7 @@ func (db *Database) GetNextVoteForUser(user User) (vote *VoteOptions, err error)
 	_, err = db.Exec(
 		"INSERT OR REPLACE INTO active_votes VALUES (?, ?, ?, ?)",
 		user.id,
-		time.Now().UnixMilli(),
+		time.Now().Unix(),
 		a,
 		b,
 	)
@@ -229,6 +229,8 @@ func (db *Database) SubmitUserVote(user User, choice string) (err error) {
 
 	// TODO scale min time to video length
 	// 	?	minTime := max(min(a.length, b.length) / 2, 90 * time.seconds)
+	fmt.Println(vote.startTime.UnixMilli())
+	fmt.Println(time.Now().UnixMilli())
 	if vote.startTime.Add(5 * time.Second).After(time.Now()) {
 		// User voting too fast, ignore vote
 		return fmt.Errorf("too fast")

--- a/readme.MD
+++ b/readme.MD
@@ -29,5 +29,8 @@ Routes
 }
 ```
 
-If the route returns `204`, then the user has completed all their votes.
-If the route returns `420`, then a predetermined deadline has passed and voting is no longer allowed.
+Unique response codes:
+
+- `204` - The end user has completed all their votes.
+- `420` - A predetermined deadline has passed and voting is no longer allowed.
+- `460` - The end user's vote has been rejected by the vote rate limit system.

--- a/routes.go
+++ b/routes.go
@@ -91,9 +91,14 @@ func routeSubmitVote(w http.ResponseWriter, req *CustomRequest, user User) {
 
 	err := database.SubmitUserVote(user, choice)
 	if err != nil {
-		w.WriteHeader(500)
-		w.Write([]byte("Failed to communicate with database."))
-		fmt.Printf("Failed to submit vote from %v of \"%s\": %v\n", user, choice, err)
+		if err.Error() == "too fast" {
+			w.WriteHeader(460)
+			w.Write([]byte("You're voting too fast"))
+		} else {
+			w.WriteHeader(500)
+			w.Write([]byte("Failed to communicate with database."))
+			fmt.Printf("Failed to submit vote from %v of \"%s\": %v\n", user, choice, err)
+		}
 		sentry.CaptureException(err)
 		return
 	}

--- a/routes.go
+++ b/routes.go
@@ -109,7 +109,7 @@ func routeSubmitVote(w http.ResponseWriter, req *CustomRequest, user User) {
 }
 
 func routeSendDeadline(w http.ResponseWriter, req *CustomRequest) {
-	bytes, err := json.Marshal(map[string]int64{"deadline": votingDeadlineUnix})
+	bytes, err := json.Marshal(map[string]int64{"deadline": votingDeadlineUnix, "clip_total": totalUnculledClipsInDb})
 
 	if err != nil {
 		w.WriteHeader(500)

--- a/www/index.html
+++ b/www/index.html
@@ -28,7 +28,7 @@
         <div class="leftPaddingBox"></div>
         <div class="rightPaddingBox"></div> -->
 
-        <p class="contentHeader headerText invis" id="countdownTracker"></p>
+        <div class="contentHeaderBox"><p class="contentHeader headerText invis" id="countdownTracker"></p><p class="contentHeader headerText invis" id="totalClipsCounter"></p></div>
         <div class="embedBox1" id="uiBox1">
             <div class="aspectRatioRespectingChad" id="clipBox1">
                 <svg id="iMissMyWife1" xmlns="http://www.w3.org/2000/svg" width="68" height="68" fill="#000000" viewBox="0 0 256 256"><path d="M216,42H40A14,14,0,0,0,26,56V200a14,14,0,0,0,14,14h64a6,6,0,0,0,5.69-4.1l15.12-45.36,37.42-15a6,6,0,0,0,3.34-3.34l15-37.42L225.9,93.69A6,6,0,0,0,230,88V56A14,14,0,0,0,216,42ZM117.77,154.43a6,6,0,0,0-3.46,3.67L99.68,202H40a2,2,0,0,1-2-2V171.17l52.58-52.58a2,2,0,0,1,2.83,0L126,151.15ZM218,83.68,174.1,98.31a6,6,0,0,0-3.67,3.46l-15.05,37.61L138.1,146.3l-36.2-36.2a14,14,0,0,0-19.8,0L38,154.2V56a2,2,0,0,1,2-2H216a2,2,0,0,1,2,2Zm9.51,33.18a6,6,0,0,0-5.41-.82L198.3,124a6,6,0,0,0-3.67,3.47L180,164l-36.56,14.63A6,6,0,0,0,140,182.3L132,206.1a6,6,0,0,0,5.69,7.9H216a14,14,0,0,0,14-14V121.73A6,6,0,0,0,227.51,116.86ZM218,200a2,2,0,0,1-2,2H146.06l4.42-13.26,36.37-14.55a6,6,0,0,0,3.34-3.34l14.55-36.37L218,130.06Z"></path></svg>
@@ -80,6 +80,7 @@
         let rightVoteButton;
         let submitVoteButton;
         let countdownTracker;
+        let totalClipsCounter;
         let errorElement;
         let brokenImage1;
         let brokenImage2;
@@ -101,6 +102,7 @@
             brokenImage1 = document.getElementById("iMissMyWife1");
             brokenImage2 = document.getElementById("iMissMyWife2");
             gigaErrorMessage = document.getElementById("gigaErrorMessage");
+            totalClipsCounter = document.getElementById("totalClipsCounter");
 
             toggleVoteButtons(false);
             toggleSubmitVoteButton(false);
@@ -117,6 +119,7 @@
                     return { deadline: -1, clip_total: 0 };
                 }
                 countdownTracker.classList.remove('invis');
+                totalClipsCounter.classList.remove('invis');
                 return response.json();
             }).then((json) => {
                 console.log(json);
@@ -125,6 +128,11 @@
                 countDownDate = json['deadline'] * 1000; 
 
                 reportedClipTotal = json['clip_total'];
+                if (reportedClipTotal === 0) {
+                    totalClipsCounter.innerHTML = "";
+                } else {
+                    totalClipsCounter.innerHTML = "Total remaining clips: " + reportedClipTotal;
+                }
 
                 setDeadlineCountdown();
             });
@@ -302,12 +310,13 @@
 
         function setDeadlineCountdown() {
             if (countDownDate > 0) {
+                /// deprecated
                 // Get totals
                 // Dumb place to put this code but it'll work
-                let runningClipTotalString = "";
-                if (!(reportedClipTotal === 0)) {
-                    runningClipTotalString = " &nbsp;&nbsp; - &nbsp;&nbsp;  Total remaining clips: " + reportedClipTotal;
-                }
+                //let runningClipTotalString = "";
+                //if (!(reportedClipTotal === 0)) {
+                //    runningClipTotalString = " &nbsp;&nbsp; - &nbsp;&nbsp;  Total remaining clips: " + reportedClipTotal;
+                //}
 
 
                 // Get today's date and time
@@ -326,9 +335,9 @@
                 // No, they are not.
                 // Arzumify
                 if (days > 0) {
-                    countdownTracker.innerHTML = "Voting ends in " + days + "d " + hours + "h " + minutes + "m" + runningClipTotalString;
+                    countdownTracker.innerHTML = "Voting ends in " + days + "d " + hours + "h " + minutes + "m";
                 } else {
-                    countdownTracker.innerHTML = "Voting ends in " + hours + "h " + minutes + "m" + runningClipTotalString;
+                    countdownTracker.innerHTML = "Voting ends in " + hours + "h " + minutes + "m";
                 }
 
                 // If the countdown is over, write some text

--- a/www/index.html
+++ b/www/index.html
@@ -71,6 +71,7 @@
     <script>
         // This is the date & time voting will end
         let countDownDate = -1
+        let reportedClipTotal = 0
 
         // element reference vars
         let clipBox1;
@@ -113,14 +114,18 @@
                 console.log(response);
                 // Format the error message as a successful payload lmfao
                 if (!(response.status === 200)) {
-                    return { deadline: -1 };
+                    return { deadline: -1, clip_total: 0 };
                 }
                 countdownTracker.classList.remove('invis');
                 return response.json();
             }).then((json) => {
                 console.log(json);
-                countDownDate = json['deadline'] * 1000 // Deadline display implimentation is built around a miliseconds timestamp. 
-                                                                // 1000x'ing it to fit is easier.
+                // Deadline display implimentation is built around a miliseconds timestamp. 
+                // 1000x'ing it to fit is easier.
+                countDownDate = json['deadline'] * 1000; 
+
+                reportedClipTotal = json['clip_total'];
+
                 setDeadlineCountdown();
             });
         }
@@ -297,6 +302,14 @@
 
         function setDeadlineCountdown() {
             if (countDownDate > 0) {
+                // Get totals
+                // Dumb place to put this code but it'll work
+                let runningClipTotalString = "";
+                if (!(reportedClipTotal === 0)) {
+                    runningClipTotalString = " &nbsp;&nbsp; - &nbsp;&nbsp;  Total remaining clips: " + reportedClipTotal;
+                }
+
+
                 // Get today's date and time
                 const now = new Date().getTime();
 
@@ -313,9 +326,9 @@
                 // No, they are not.
                 // Arzumify
                 if (days > 0) {
-                    countdownTracker.innerHTML = "Voting ends in " + days + "d " + hours + "h " + minutes + "m";
+                    countdownTracker.innerHTML = "Voting ends in " + days + "d " + hours + "h " + minutes + "m" + runningClipTotalString;
                 } else {
-                    countdownTracker.innerHTML = "Voting ends in " + hours + "h " + minutes + "m";
+                    countdownTracker.innerHTML = "Voting ends in " + hours + "h " + minutes + "m" + runningClipTotalString;
                 }
 
                 // If the countdown is over, write some text

--- a/www/index.html
+++ b/www/index.html
@@ -310,7 +310,7 @@
                 if (days > 0) {
                     countdownTracker.innerHTML = "Voting ends in " + days + "d " + hours + "h " + minutes + "m";
                 } else {
-                    countdownTracker.innerHTML = "Voting ends in " + hours + "h " + minutes + "m " ;
+                    countdownTracker.innerHTML = "Voting ends in " + hours + "h " + minutes + "m";
                 }
 
                 // If the countdown is over, write some text

--- a/www/index.html
+++ b/www/index.html
@@ -212,9 +212,14 @@
                 // Internal error code -1 : Deadline has passed error 
                 } else if (code === -1) {
                     messageToUse = "The voting deadline has been reached, and voting has closed.";
+                } else if (code === 460) {
+                    messageToUse = "You're voting too quickly! Slow down!";
                 }
 
                 let errorToUse = `Error ${code}; `;
+                if (code === 460) {
+                    errorToUse = "";
+                }
 
                 // Error codes where the message will get be giga, ie needs to be big so users will SEE them
                 // All errors below 0 are internal client-side only error codes

--- a/www/styling.css
+++ b/www/styling.css
@@ -228,6 +228,18 @@ form {
 }
 
 
+.contentHeaderBox {
+    grid-area: head;
+    display: grid;
+    justify-content: center;
+    align-content: center;
+    grid-template-columns: max-content;
+    grid-template-rows: max-content max-content;
+    column-gap: 36px;
+    row-gap: 8px;
+}
+
+
 @media (min-width: 950px) { 
     .contentWrapper {
         grid-template-columns: 1fr minmax(300px, 560px) 2px minmax(300px, 560px) 1fr;
@@ -256,6 +268,11 @@ form {
         opacity: 0;
         visibility: hidden;
     }
+
+    .contentHeaderBox {
+        grid-template-columns: max-content max-content;
+        grid-template-rows: max-content;
+    }
 }
 
 /*
@@ -277,15 +294,8 @@ form {
 */
 
 
-
-
-
 .contentHeader {
-    grid-area: head;
     text-align: center;
-    vertical-align: middle;
-    line-height: 55px;
-    display: table-cell;
     transition: opacity 1s;
 }
 


### PR DESCRIPTION
- _Total clips counter_. Backend now keeps track of the total amount of clips considered unculled. This information is sent to the frontend via the deadline route, the payload of which has been modified to fit.

- _Vote submission rate limiting_: A cooldown between votes. Currently set to 5 seconds, feel free to suggest a different number.

- Backend now logs the time when a vote is submitted. Rationale: This may be useful when debugging.

- A couple bug fixes and tiny improvements